### PR TITLE
Objects As Values?

### DIFF
--- a/lib/Data/Verifier/Field.pm
+++ b/lib/Data/Verifier/Field.pm
@@ -19,7 +19,7 @@ Predicate that returns true if this field has an original value.
 
 has original_value => (
     is => 'rw',
-    isa => 'Maybe[Str|ArrayRef|HashRef[Str]]',
+    isa => 'Maybe[Str|ArrayRef|HashRef[Str]|Object]',
     predicate => 'has_original_value'
 );
 
@@ -36,7 +36,7 @@ Predicate that returns true if this field has a post filter value.
 
 has post_filter_value => (
     is => 'rw',
-    isa => 'Maybe[Str|ArrayRef|HashRef[Str]]',
+    isa => 'Maybe[Str|ArrayRef|HashRef[Str]|Object]',
     predicate => 'has_post_filter_value'
 );
 


### PR DESCRIPTION
Adjusted type constraints to allow Field object's original_value and post_filter_value attributes to hold objects. ticket reference: #URMOM

Note: I didn't really explore the deeper implications of this-- it does what I need it to for the ways we're using D::V and the test suite still passes-- but it might break the filters, etc. Your thoughts? 
